### PR TITLE
Removed Lower Level Debugging for AMQP Messages / Updated RiskAssessmentReply Payload

### DIFF
--- a/src/eBayEnterprise/RetailOrderManagement/Api/AmqpApi.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Api/AmqpApi.php
@@ -196,9 +196,6 @@ class AmqpApi implements IAmqpApi
         if ($message) {
             // direct delivery_info array access recommended in PhpAmqpLib documentation
             $this->channel->basic_ack($message->delivery_info['delivery_tag']);
-
-            $logMessage = 'Message Payload:';
-            $this->logger->debug($logMessage, $this->getRequestUrlLogData($message->body));
         }
         return $message;
     }
@@ -215,22 +212,13 @@ class AmqpApi implements IAmqpApi
         return $this;
     }
 
-    protected function getRequestUrlLogData($message=null)
+    protected function getRequestUrlLogData()
     {
         $context = $this->getContext();
-        if($message)
-        {
-                $logData = [
-                  'rom_request_url' => $this->config->getEndpoint(),
-                  'queue_name' => $this->config->getQueueName(),
-                  'body' => $message,
-                ];
-        } else {
-                $logData = [
-                    'rom_request_url' => $this->config->getEndpoint(),
-                    'queue_name' => $this->config->getQueueName(),
-                ];
-        }
+        $logData = [
+             'rom_request_url' => $this->config->getEndpoint(),
+             'queue_name' => $this->config->getQueueName(),
+        ];
         return $context ? $context->getMetaData(__CLASS__, $logData) : $logData;
     }
 

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/PayloadConfigMap.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/PayloadConfigMap.php
@@ -3989,7 +3989,6 @@ return call_user_func(function () {
         [
           'validator' => $requiredFieldsValidator,
                  'params' => [
-                        'getMockOrderEvent',
                         'getResponseCode',
                  ]
              ]

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/IRiskAssessmentReply.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/IRiskAssessmentReply.php
@@ -28,10 +28,6 @@ interface IRiskAssessmentReply extends IPayload, IOrderEvent
     const ROOT_NODE = 'RiskAssessmentReply';
     const XSD = '/checkout/1.0/Risk-Service-RiskAssessment-1.0.xsd';
 
-    public function getMockOrderEvent();
-    public function setMockOrderEvent($mockOrderEvent);
     public function getResponseCode();
     public function setResponseCode($responseCode);
-    public function getSessionId();
-    public function setSessionId($sessionId);
 }

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/RiskAssessmentReply.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/RiskAssessmentReply.php
@@ -29,6 +29,8 @@ class RiskAssessmentReply implements IRiskAssessmentReply
     protected $_mockOrderEvent;
     protected $_responseCode;
     protected $_sessionId;
+    protected $_reasonCode;
+    protected $_reasonCodeDescription;
 
     /**
      * @param IValidatorIterator
@@ -51,12 +53,16 @@ class RiskAssessmentReply implements IRiskAssessmentReply
         $this->parentPayload = $parentPayload;
         $this->extractionPaths = [
             'orderId' => 'string(x:OrderId)',
-	    'transactionDeviceInfo' => 'string(x:TransactionDeviceInfo)',
-	    '_mockOrderEvent' => 'string(x:MockOrderEvent)',
 	    '_responseCode' => 'string(x:ResponseCode)',
 	    'storeId' => 'string(x:StoreId)',
-	    '_sessionId' => 'string(@sessionId)',
         ];
+	$this->optionalExtractionPaths = [
+	    'transactionDeviceInfo' => 'string(x:TransactionDeviceInfo)',
+	    '_mockOrderEvent' => 'string(x:MockOrderEvent)',
+	    '_reasonCode' => 'string(x:ReasonCode)',
+	    '_reasonCodeDescription' => 'string(x:ReasonCodeDescription)',
+	    '_sessionId' => 'string(@sessionId)',
+	];
     }
     /**
      * Serialize the various parts of the payload into XML strings and
@@ -74,10 +80,12 @@ class RiskAssessmentReply implements IRiskAssessmentReply
     protected function serializeRiskReply()
     {
         return sprintf(
-	    '<MockOrderEvent>%s</MockOrderEvent>' .
+	    '<OrderId>%s</OrderId>' .
 	    '<ResponseCode>%s</ResponseCode>' .
-	    $this->xmlEncode($this->getMockOrderEvent()),
-	    $this->xmlEncode($this->getResponseCode())
+	    '<StoreId>%s</StoreId>',
+	    $this->xmlEncode($this->getCustomerOrderId()),
+	    $this->xmlEncode($this->getResponseCode()),
+	    $this->xmlEncode($this->getStoreId())
         );
     }
     /**
@@ -108,13 +116,6 @@ class RiskAssessmentReply implements IRiskAssessmentReply
         return static::ROOT_NODE;
     }
 	   
-    protected function getRootAttributes()
-    {
-        return [
-            '_sessionId' => $this->getSessionId(),
-        ];
-    }
-
     public function getMockOrderEvent()
     {
 	return $this->_mockOrderEvent;
@@ -135,6 +136,28 @@ class RiskAssessmentReply implements IRiskAssessmentReply
     {
 	$this->_responseCode = $responseCode;
 	return $this;
+    }
+
+    public function getReasonCode()
+    {
+        return $this->_reasonCode;
+    }
+
+    public function setReasonCode($reasonCode)
+    {
+        $this->_reasonCode = $reasonCode;
+        return $this;
+    }
+
+    public function getReasonCodeDescription()
+    {
+        return $this->_reasonCodeDescription;
+    }
+
+    public function setReasonCodeDescription($reasonCodeDescription)
+    {
+        $this->_reasonCodeDescription = $reasonCodeDescription;
+        return $this;
     }
 
     public function getSessionId()

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/Validator/XsdSchemaValidator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/Validator/XsdSchemaValidator.php
@@ -33,6 +33,8 @@ class XsdSchemaValidator implements Payload\ISchemaValidator
      */
     public function validate($xmlString, $schemaFile = null)
     {
+	print_r("XML String: ". $xmlString);
+
         $doc = $this->loadXmlDoc($xmlString);
         $originalUseErrors = $this->setupValidationErrorHandling();
         $isValid = $doc->schemaValidate($schemaFile);

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/Validator/XsdSchemaValidator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/Validator/XsdSchemaValidator.php
@@ -33,8 +33,6 @@ class XsdSchemaValidator implements Payload\ISchemaValidator
      */
     public function validate($xmlString, $schemaFile = null)
     {
-	print_r("XML String: ". $xmlString);
-
         $doc = $this->loadXmlDoc($xmlString);
         $originalUseErrors = $this->setupValidationErrorHandling();
         $isValid = $doc->schemaValidate($schemaFile);

--- a/src/eBayEnterprise/RetailOrderManagement/Schemas/checkout/1.0/Risk-Service-RiskAssessment-1.0.xsd
+++ b/src/eBayEnterprise/RetailOrderManagement/Schemas/checkout/1.0/Risk-Service-RiskAssessment-1.0.xsd
@@ -1,88 +1,119 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://api.gsicommerce.com/schema/checkout/1.0" targetNamespace="http://api.gsicommerce.com/schema/checkout/1.0" elementFormDefault="qualified" attributeFormDefault="unqualified" version="${project.version}">
-  <xsd:include schemaLocation="Risk-Service-Datatypes-1.0.xsd"/>
-  <xsd:element name="RiskAssessmentRequest" type="RiskAssessmentRequestType">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	        xmlns="http://api.gsicommerce.com/schema/checkout/1.0" 
+	        targetNamespace="http://api.gsicommerce.com/schema/checkout/1.0"
+	        elementFormDefault="qualified" 
+	        attributeFormDefault="unqualified" 
+            version="${project.version}">
+	
+	<xsd:include schemaLocation="Risk-Service-Datatypes-1.0.xsd"/>
+	
+	<xsd:element name="RiskAssessmentRequest" type="RiskAssessmentRequestType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">
 				The full detail for an event being submitted for fraud validation
 			</xsd:documentation>
-    </xsd:annotation>
-  </xsd:element>
-  <xsd:element name="RiskAssessmentReply" type="RiskAssessmentReplyType">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="RiskAssessmentReply" type="RiskAssessmentReplyType">
+		<xsd:annotation>
+			<xsd:documentation xml:lang="en">
 				The response for an event submitted for fraud validation
 			</xsd:documentation>
-    </xsd:annotation>
-  </xsd:element>
-  <xsd:element name="Fault">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
+		</xsd:annotation>
+	</xsd:element>
+
+	<!--
+	     Renamed the follwoign element to avoid redundant type definition error as the same element exists in Checkout-Service-Fault-1.0.xsd 
+	-->
+    <xsd:element name="Fault_DUPLICATE"> 
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
                 The response for when an error occurs with an event submitted for fraud validation
             </xsd:documentation>
-    </xsd:annotation>
-    <xsd:complexType>
-      <xsd:sequence>
-        <xsd:element name="OrderId" type="xsd:string">
-          <xsd:annotation>
-            <xsd:documentation xml:lang="en">
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="OrderId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
                             Order ID from the RiskAssessmentRequest
                         </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-        <xsd:element name="Code" type="xsd:string">
-          <xsd:annotation>
-            <xsd:documentation xml:lang="en">
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="Code" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
                             Error code or exception name
                         </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-        <xsd:element name="Description" type="xsd:string">
-          <xsd:annotation>
-            <xsd:documentation xml:lang="en">
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="Description" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
                             Description of the error
                         </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-        <xsd:element name="StoreId" type="xsd:string">
-          <xsd:annotation>
-            <xsd:documentation xml:lang="en">
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StoreId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
                             Store ID from the RiskAssessmentRequest
                         </xsd:documentation>
-          </xsd:annotation>
-        </xsd:element>
-      </xsd:sequence>
-    </xsd:complexType>
-  </xsd:element>
-  <xsd:complexType name="RiskAssessmentRequestType">
-    <xsd:sequence>
-      <xsd:element name="Order" type="OrderDataType"/>
-      <xsd:element name="ServerInfo" type="ServerInfoType">
-        <xsd:annotation>
-          <xsd:documentation xml:lang="en">
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="sessionId" type="RequestId" use="optional"/>
+        </xsd:complexType>
+    </xsd:element>
+	
+	<xsd:complexType name="RiskAssessmentRequestType">
+	  	<xsd:sequence>
+	        <xsd:element name="Order" type="OrderDataType"/>
+	        <xsd:element name="ServerInfo" type="ServerInfoType">
+				<xsd:annotation>
+                	<xsd:documentation xml:lang="en">
                     	Definition: Information collected about the event on the Web application server.
                     </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="DeviceInfo" type="DeviceInfoType" minOccurs="0">
-        <xsd:annotation>
-          <xsd:documentation xml:lang="en">
+                </xsd:annotation>
+            </xsd:element>
+	        <xsd:element name="DeviceInfo" type="DeviceInfoType" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation xml:lang="en">
                         Definition: Information collected about the device both on the device and at the Web application server.
                         </xsd:documentation>
-        </xsd:annotation>
-      </xsd:element>
-      <xsd:element name="CustomProperties" type="CustomPropertiesType" minOccurs="0"/>
-    </xsd:sequence>
-  </xsd:complexType>
-  <xsd:complexType name="RiskAssessmentReplyType">
-    <xsd:sequence>
-      <xsd:element name="OrderId" type="OrderIdType"/>
-      <xsd:element name="TransactionDeviceInfo" type="TransactionDeviceInfoType" minOccurs="0"/>
-      <xsd:element name="RiskInfo" type="RiskInfoType"/>
-      <xsd:element name="MockOrderEvent" type="xsd:boolean" minOccurs="0"/>
-      <xsd:element name="ResponseCode" type="ResponseCodeType"/>
-      <xsd:element name="StoreId" type="StoreIdType"/>
-      <xsd:element name="any" type="AnyExtensionType" minOccurs="0"/>
-    </xsd:sequence>
-  </xsd:complexType>
+                    </xsd:annotation>
+                </xsd:element>
+	        <xsd:element name="CustomProperties" type="CustomPropertiesType" minOccurs="0"/>
+	  	</xsd:sequence>
+        <xsd:attribute name="sessionId" type="RequestId" use="optional"/>
+  	</xsd:complexType>
+  	
+  	<xsd:complexType name="RiskAssessmentReplyType">
+  		<xsd:sequence>
+  			<xsd:element name="OrderId" type="OrderIdType"/>
+  			<xsd:element name="TransactionDeviceInfo" type="TransactionDeviceInfoType" minOccurs="0"/>
+  			<xsd:element name="RiskInfo" type="RiskInfoType" minOccurs="0"/>
+  			<xsd:element name="MockOrderEvent" type="xsd:boolean" minOccurs="0"/>
+  			<xsd:element name="ResponseCode" type="ResponseCodeType"/>
+  			<xsd:element name="StoreId" type="StoreIdType" />
+			<xsd:element name="ReasonCode" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                        Definition: The reason code mapped from the responses based on fraud net response.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ReasonCodeDescription" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">
+                        Definition: The reason code description for the reason code provided above.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+  			<xsd:element name="any" type="AnyExtensionType" minOccurs="0"/>
+  		</xsd:sequence>
+        <xsd:attribute name="sessionId" type="RequestId" use="optional"/>
+  	</xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
Removed Lower Level Debugging for AMQP Messages / Updated RiskAssessmentReply Payload

-Removed AMQP Log Level Debugging, should be in modules only.
-Added ReasonCode / ReasonCodeDescription optional fields for order states
-Fixed serialize() method for outputting RiskAssessmentReply message
-Updated RiskAssessment XSD schema to current version (per request of Risk Team) at:

https://gitlab.gspt.net/integration-services/checkout-schema/blob/master/src/main/resources/checkout/1.0/Risk-Service-RiskAssessment-1.0.xsd
