### PR TITLE
MPTF-150v2

### DIFF
--- a/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/RiskAssessmentReply.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/Risk/RiskAssessmentReply.php
@@ -187,11 +187,4 @@ class RiskAssessmentReply implements IRiskAssessmentReply
 	$mockOrderEvent = $this->getMockOrderEvent();
 	return $mockOrderEvent ? "<MockOrderEvent>{$this->xmlEncode($mockOrderEvent)}</MockOrderEvent>" : '';
     }
-
-    protected function getRootAttributes()
-    {
-        return [
-            '_sessionId' => $this->getSessionId(),
-        ];
-    }
 }


### PR DESCRIPTION
Remote getRootAttributes() method as this is only for XSD attributes that are required and not optional. 
